### PR TITLE
Unsaved changes fix

### DIFF
--- a/src/app/components/article/article.component.ts
+++ b/src/app/components/article/article.component.ts
@@ -226,21 +226,17 @@ export class ArticleComponent implements OnInit, OnDestroy {
   // ===end form setup & breakdown
 
   // ===EDITING STUFF
-  updateUserEditingStatus = (status: boolean) => {
-    this.articleSvc.updateArticleEditStatus(
-      this.articleId,
-      this.loggedInUser.uid,
-      status
-    );
-  };
+  updateUserEditingStatus = (status: boolean) => this.articleSvc.updateArticleEditStatus(
+    this.articleId,
+    this.loggedInUser.uid,
+    status
+  );
 
   resetEditStates = () => {
-    this.updateUserEditingStatus(false);
-    // this.currentArticleEditors[this.loggedInUser.uid] = false;
     this.articleEditForm.markAsPristine();
-    // this.coverImageFile = null;
-
+    // this.coverImageFile = null;  
     this.activateCtrl(ECtrlNames.none);
+    return this.updateUserEditingStatus(false);
   };
 
   addTag = (tag: string) => {
@@ -315,8 +311,9 @@ export class ArticleComponent implements OnInit, OnDestroy {
               this.articleId
             );
             this.resetEditSessionTimeout();
-            // TODO: Ensure unsaved chanes are actually being checked upon route change
-            this.resetEditStates(); // Unsaved chagnes checked upon route change
+            // TODO: Ensure unsaved changes are actually being checked upon route change
+            await this.resetEditStates(); // This could still result in race condition where real time updates are too slow.
+            this.router.navigate([`article/${this.articleId}`]);
           } catch (error) {
             this.dialogSvc.openMessageDialog(
               'Error creating article',


### PR DESCRIPTION
This solves the odd behavior of warning a user that they might loose unsaved changes when they save a new article.

The user is still warned if they attempt to navigate away from a new article without saving their changes first.